### PR TITLE
Release 1.3.3

### DIFF
--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -14,25 +14,25 @@
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
         <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
         <PackageReference Include="IPinfo" Version="3.0.1" />
-        <PackageReference Include="MailKit" Version="4.9.0" />
+        <PackageReference Include="MailKit" Version="4.11.0" />
         <PackageReference Include="MediatR" Version="12.4.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="QRCoder" Version="1.6.0" />
@@ -45,13 +45,13 @@
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.Graylog" Version="3.1.1" />
         <PackageReference Include="Serilog.Sinks.SyslogMessages" Version="4.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
-        <PackageReference Include="Stripe.net" Version="47.2.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+        <PackageReference Include="Stripe.net" Version="47.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.2" />
         <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-        <PackageReference Include="System.Runtime.Caching" Version="9.0.0" />
-        <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.1" />
+        <PackageReference Include="System.Runtime.Caching" Version="9.0.2" />
+        <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
         <PackageReference Include="X.PagedList.Mvc.Core" Version="10.5.7" />
         <PackageReference Include="ZymLabs.NSwag.FluentValidation" Version="0.7.1" />
     </ItemGroup>


### PR DESCRIPTION
This pull request updates several package dependencies in the `CommonUtilities` project to their latest versions. The changes ensure that the project uses the most recent and secure versions of these packages.

Dependency updates:

* Updated `MailKit` from version `4.9.0` to `4.11.0`.
* Updated multiple `Microsoft` packages to newer versions, such as `Microsoft.AspNetCore.Authorization` from `9.0.0` to `9.0.2` and `Microsoft.EntityFrameworkCore` from `9.0.0` to `9.0.2`.
* Updated `SixLabors.ImageSharp` from version `3.1.6` to `3.1.7`.
* Updated `Stripe.net` from version `47.2.0` to `47.4.0`.
* Updated `Swashbuckle.AspNetCore` from version `7.2.0` to `7.3.1`.