### PR TITLE
Release 1.3.7

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -2,7 +2,11 @@ name: Cross-Platform Build
 
 on:
   workflow_dispatch:
-
+    inputs:
+      release_version:
+        description: 'Desired Release Version (e.g., v1.0.0)'
+        required: true
+        type: string
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -26,16 +30,26 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Restore dependencies
-        run: dotnet restore EasyKit/EasyKit.csproj
+        run: dotnet restore CommonUtilities/CommonUtilities.csproj
 
       - name: Clean project
-        run: dotnet clean EasyKit/EasyKit.csproj
+        run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
       - name: Publish single-file executable
-        run: dotnet publish EasyKit/EasyKit.csproj -c Release -r ${{ matrix.runtime }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj -c Release -r ${{ matrix.runtime }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.os }}-${{ matrix.runtime }}
           path: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        with:
+          tag_name: ${{ github.event.inputs.release_version }}
+          name: ${{ github.event.inputs.release_version }}
+          files: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ FodyWeavers.xsd
 
 # Rider IDE
 *.idea
+
+# Hide report
+report.md


### PR DESCRIPTION
This pull request updates the cross-platform build workflow to add support for specifying a release version during manual workflow dispatch and introduces changes to the build process and artifact handling. The most important changes include adding an input parameter for the release version, switching the target project from `EasyKit` to `CommonUtilities`, and automating GitHub release creation.

### Workflow Enhancements:

* [`.github/workflows/cross-platform-build.yml`](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL5-R9): Added an `inputs` section under `workflow_dispatch` to allow specifying a `release_version` when manually triggering the workflow. This input is required and ensures better control over release versioning.

### Build Process Updates:

* [`.github/workflows/cross-platform-build.yml`](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL29-R55): Updated the build steps to target the `CommonUtilities/CommonUtilities.csproj` project instead of `EasyKit/EasyKit.csproj` for dependency restoration, cleaning, and publishing. This reflects a shift in the focus of the build process.

### Artifact and Release Automation:

* [`.github/workflows/cross-platform-build.yml`](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL29-R55): Added a step to create a GitHub release using the `softprops/action-gh-release` action. The release is triggered when a tag is pushed or the workflow is manually dispatched. It uses the specified `release_version` and uploads the published artifacts.