### PR TITLE
Beta 1.3.8-1

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Clean project
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
-      - name: Publish single-file executable
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj -c Release -r ${{ matrix.runtime }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
+      - name: Publish library
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}-${{ matrix.runtime }}
-          path: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/
+          name: ${{ matrix.os }}-build
+          path: ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +50,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/*
+          files: ./publish/${{ matrix.os }}/CommonUtilities/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/cross-platform-build.yml` file to modify the build and release process for the `CommonUtilities` project. The changes focus on transitioning from publishing a single-file executable to publishing a library, along with adjustments to the artifact upload and GitHub release steps.

### Build process changes:
* Replaced the "Publish single-file executable" step with a "Publish library" step. The new step uses `--self-contained false` and `/p:UseAppHost=false` options, and outputs the build to a `./publish/${{ matrix.os }}/CommonUtilities` directory.

### Artifact and release adjustments:
* Updated the artifact upload path to match the new library output directory (`./publish/${{ matrix.os }}/CommonUtilities`) and simplified the artifact name to `${{ matrix.os }}-build`.
* Modified the GitHub release configuration to reference the new library output path for uploaded files (`./publish/${{ matrix.os }}/CommonUtilities/*`).