### PR TITLE
Beta 1.3.8-2

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -43,6 +43,23 @@ jobs:
         with:
           name: ${{ matrix.os }}-build
           path: ./publish/${{ matrix.os }}/CommonUtilities
+          overwrite: true
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Ubuntu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-latest-build
+          path: ./downloaded-artifacts/ubuntu-latest-build
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-latest-build
+          path: ./downloaded-artifacts/windows-latest-build
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +67,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: ./publish/${{ matrix.os }}/CommonUtilities/*
+          files: ./downloaded-artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the cross-platform build workflow in `.github/workflows/cross-platform-build.yml` to improve the release process by adding steps for downloading build artifacts and consolidating them for release.

### Workflow improvements:

* Added a new `release` job that runs on `ubuntu-latest` and depends on the `build` job.
* Included steps to download build artifacts for both Ubuntu and Windows using `actions/download-artifact@v4`. These artifacts are stored in the `./downloaded-artifacts/` directory.
* Updated the `Create GitHub Release` step to use the consolidated artifact directory (`./downloaded-artifacts/**/*`) instead of OS-specific paths.