### PR TITLE
Beta 1.3.8-3

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -11,14 +11,15 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        runtime: [win-x64, linux-x64]
         include:
-          - os: ubuntu-latest
-            runtime: linux-x64
           - os: windows-latest
+            arch: x64
             runtime: win-x64
+          - os: windows-latest
+            arch: x86
+            runtime: win-x86
 
     steps:
       - name: Checkout repository
@@ -36,30 +37,29 @@ jobs:
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
       - name: Publish library
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}/CommonUtilities
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration context7 --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-build
-          path: ./publish/${{ matrix.os }}/CommonUtilities
+          name: ${{ matrix.os }}-${{ matrix.arch }}-build
+          path: ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
           overwrite: true
 
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download Ubuntu artifact
+      - name: Download Windows x64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ubuntu-latest-build
-          path: ./downloaded-artifacts/ubuntu-latest-build
-
-      - name: Download Windows artifact
+          name: windows-latest-x64-build # Match new artifact name
+          path: ./downloaded-artifacts/windows-latest-x64-build
+      - name: Download Windows x86 artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-latest-build
-          path: ./downloaded-artifacts/windows-latest-build
+          name: windows-latest-x86-build # Match new artifact name
+          path: ./downloaded-artifacts/windows-latest-x86-build
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Clean project
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
-      - name: Publish single-file executable
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj -c Release -r ${{ matrix.runtime }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
+      - name: Publish library
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}-${{ matrix.runtime }}
-          path: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/
+          name: ${{ matrix.os }}-build
+          path: ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +50,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/*
+          files: ./publish/${{ matrix.os }}/CommonUtilities/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -43,6 +43,23 @@ jobs:
         with:
           name: ${{ matrix.os }}-build
           path: ./publish/${{ matrix.os }}/CommonUtilities
+          overwrite: true
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Ubuntu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-latest-build
+          path: ./downloaded-artifacts/ubuntu-latest-build
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-latest-build
+          path: ./downloaded-artifacts/windows-latest-build
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +67,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: ./publish/${{ matrix.os }}/CommonUtilities/*
+          files: ./downloaded-artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the cross-platform build workflow to add support for Windows x86 architecture and improve artifact naming for better clarity. The most important changes include modifying the build matrix to include the new architecture, updating the publish and artifact upload steps to reflect the new structure, and adjusting the release process to handle the additional artifacts.

### Build matrix updates:
* Added support for Windows x86 architecture by including `arch: x86` in the build matrix and restructuring the matrix configuration.

### Publish and artifact handling:
* Updated the `dotnet publish` command to include architecture in the output directory path and artifact names, ensuring proper separation of builds by architecture.
* Adjusted artifact upload configurations to use the new naming convention (`${{ matrix.os }}-${{ matrix.arch }}-build`) and directory structure.

### Release process adjustments:
* Modified the release job to download and handle separate artifacts for Windows x64 and Windows x86 builds, reflecting the updated naming convention.