### PR TITLE
Beta 1.3.8-7

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Desired Release Version (e.g., v1.0.0)'
+        description: "Desired Release Version (e.g., v1.0.0)"
         required: true
         type: string
 jobs:
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: "8.0.x"
 
       - name: Restore dependencies
         run: dotnet restore CommonUtilities/CommonUtilities.csproj
@@ -49,6 +49,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - name: Download Windows x64 artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -74,6 +74,8 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: ./release-assets/*.zip
+          files: |
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-x86.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -37,13 +37,18 @@ jobs:
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
       - name: Publish library
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration context7 --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
 
-      - name: Upload artifact
+      - name: Zip ${{ matrix.arch }} output
+        run: |
+          Compress-Archive -Path ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities/* -DestinationPath ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
+        shell: pwsh
+
+      - name: Upload ${{ matrix.arch }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-${{ matrix.arch }}-build
-          path: ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
+          name: CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
+          path: ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
           overwrite: true
 
   release:
@@ -55,13 +60,13 @@ jobs:
       - name: Download Windows x64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-latest-x64-build # Match new artifact name
-          path: ./downloaded-artifacts/windows-latest-x64-build
+          name: CommonUtilities-${{ inputs.release_version }}-x64.zip
+          path: ./release-assets/CommonUtilities-${{ inputs.release_version }}-x64.zip
       - name: Download Windows x86 artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-latest-x86-build # Match new artifact name
-          path: ./downloaded-artifacts/windows-latest-x86-build
+          name: CommonUtilities-${{ inputs.release_version }}-x86.zip
+          path: ./release-assets/CommonUtilities-${{ inputs.release_version }}-x86.zip
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -69,6 +74,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: ./downloaded-artifacts/**/*
+          files: ./release-assets/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -61,12 +61,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: CommonUtilities-${{ inputs.release_version }}-x64.zip
-          path: ./release-assets/CommonUtilities-${{ inputs.release_version }}-x64.zip
+          path: ./release-assets
       - name: Download Windows x86 artifact
         uses: actions/download-artifact@v4
         with:
           name: CommonUtilities-${{ inputs.release_version }}-x86.zip
-          path: ./release-assets/CommonUtilities-${{ inputs.release_version }}-x86.zip
+          path: ./release-assets
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -11,14 +11,15 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        runtime: [win-x64, linux-x64]
         include:
-          - os: ubuntu-latest
-            runtime: linux-x64
           - os: windows-latest
+            arch: x64
             runtime: win-x64
+          - os: windows-latest
+            arch: x86
+            runtime: win-x86
 
     steps:
       - name: Checkout repository
@@ -36,30 +37,29 @@ jobs:
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
       - name: Publish library
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}/CommonUtilities
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration context7 --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-build
-          path: ./publish/${{ matrix.os }}/CommonUtilities
+          name: ${{ matrix.os }}-${{ matrix.arch }}-build
+          path: ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
           overwrite: true
 
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download Ubuntu artifact
+      - name: Download Windows x64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ubuntu-latest-build
-          path: ./downloaded-artifacts/ubuntu-latest-build
-
-      - name: Download Windows artifact
+          name: windows-latest-x64-build # Match new artifact name
+          path: ./downloaded-artifacts/windows-latest-x64-build
+      - name: Download Windows x86 artifact
         uses: actions/download-artifact@v4
         with:
-          name: windows-latest-build
-          path: ./downloaded-artifacts/windows-latest-build
+          name: windows-latest-x86-build # Match new artifact name
+          path: ./downloaded-artifacts/windows-latest-x86-build
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Clean project
         run: dotnet clean CommonUtilities/CommonUtilities.csproj
 
-      - name: Publish single-file executable
-        run: dotnet publish CommonUtilities/CommonUtilities.csproj -c Release -r ${{ matrix.runtime }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
+      - name: Publish library
+        run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.os }}-${{ matrix.runtime }}
-          path: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/
+          name: ${{ matrix.os }}-build
+          path: ./publish/${{ matrix.os }}/CommonUtilities
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +50,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: EasyKit/bin/Release/net8.0/${{ matrix.runtime }}/publish/*
+          files: ./publish/${{ matrix.os }}/CommonUtilities/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -43,6 +43,23 @@ jobs:
         with:
           name: ${{ matrix.os }}-build
           path: ./publish/${{ matrix.os }}/CommonUtilities
+          overwrite: true
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Ubuntu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-latest-build
+          path: ./downloaded-artifacts/ubuntu-latest-build
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-latest-build
+          path: ./downloaded-artifacts/windows-latest-build
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -50,6 +67,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
-          files: ./publish/${{ matrix.os }}/CommonUtilities/*
+          files: ./downloaded-artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a small adjustment to the `.github/workflows/cross-platform-build.yml` file. The change simplifies the `path` parameter for downloading artifacts by removing the specific file name and pointing to the `./release-assets` directory instead.

* [`.github/workflows/cross-platform-build.yml`](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL64-R69): Updated the `path` parameter in the `actions/download-artifact` steps to use the `./release-assets` directory, streamlining artifact handling.