### PR TITLE
Release 1.4.1

### DIFF
--- a/CommonUtilities/Interfaces/IContextMenuManager.cs
+++ b/CommonUtilities/Interfaces/IContextMenuManager.cs
@@ -1,0 +1,39 @@
+using CommonUtilities.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CommonUtilities.Interfaces
+{
+    /// <summary>
+    /// Defines the contract for managing context menu entries.
+    /// </summary>
+    public interface IContextMenuManager
+    {
+        /// <summary>
+        /// Adds a new entry to the context menu.
+        /// </summary>
+        /// <param name="entry">The context menu entry to add.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task AddEntryAsync(ContextMenuEntry entry);
+
+        /// <summary>
+        /// Removes an entry from the context menu.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to remove.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task RemoveEntryAsync(string entryId);
+
+        /// <summary>
+        /// Checks if a context menu entry exists.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to check.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains true if the entry exists; otherwise, false.</returns>
+        Task<bool> CheckEntryExistsAsync(string entryId);
+
+        /// <summary>
+        /// Retrieves all context menu entries.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a collection of all context menu entries.</returns>
+        Task<IEnumerable<ContextMenuEntry>> GetEntriesAsync();
+    }
+}

--- a/CommonUtilities/Models/ContextMenuEntry.cs
+++ b/CommonUtilities/Models/ContextMenuEntry.cs
@@ -1,0 +1,45 @@
+using CommonUtilities.Models.Enums;
+
+namespace CommonUtilities.Models
+{
+    /// <summary>
+    /// Represents an entry in the context menu.
+    /// </summary>
+    public class ContextMenuEntry
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the context menu entry.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text displayed in the context menu.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the executable or command to run.
+        /// </summary>
+        public string Command { get; set; }
+
+        /// <summary>
+        /// Gets or sets the arguments for the command.
+        /// </summary>
+        public string Arguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional path to an icon for the context menu entry.
+        /// </summary>
+        public string? IconPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target type for the context menu entry (e.g., File, Folder).
+        /// </summary>
+        public TargetType TargetType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scope of the context menu entry (e.g., User, System).
+        /// </summary>
+        public MenuScope Scope { get; set; }
+    }
+}

--- a/CommonUtilities/Models/Enums/MenuScope.cs
+++ b/CommonUtilities/Models/Enums/MenuScope.cs
@@ -1,0 +1,17 @@
+namespace CommonUtilities.Models.Enums
+{
+    /// <summary>
+    /// Specifies the scope for a context menu entry.
+    /// </summary>
+    public enum MenuScope
+    {
+        /// <summary>
+        /// The context menu entry is for the current user.
+        /// </summary>
+        User,
+        /// <summary>
+        /// The context menu entry is for all users on the system.
+        /// </summary>
+        System
+    }
+}

--- a/CommonUtilities/Models/Enums/TargetType.cs
+++ b/CommonUtilities/Models/Enums/TargetType.cs
@@ -1,0 +1,25 @@
+namespace CommonUtilities.Models.Enums
+{
+    /// <summary>
+    /// Specifies the target type for a context menu entry.
+    /// </summary>
+    public enum TargetType
+    {
+        /// <summary>
+        /// The context menu entry targets a file.
+        /// </summary>
+        File,
+        /// <summary>
+        /// The context menu entry targets a folder.
+        /// </summary>
+        Folder,
+        /// <summary>
+        /// The context menu entry targets a drive.
+        /// </summary>
+        Drive,
+        /// <summary>
+        /// The context menu entry targets the background of a folder.
+        /// </summary>
+        Background
+    }
+}

--- a/CommonUtilities/Services/OSIntegration/Linux/LinuxContextMenuManager.cs
+++ b/CommonUtilities/Services/OSIntegration/Linux/LinuxContextMenuManager.cs
@@ -1,0 +1,300 @@
+using CommonUtilities.Interfaces;
+using CommonUtilities.Models;
+using CommonUtilities.Models.Enums;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CommonUtilities.Services.OSIntegration.Linux
+{
+    /// <summary>
+    /// Manages context menu entries for Linux desktop environments.
+    /// Creates .desktop files for file manager actions.
+    /// </summary>
+    public class LinuxContextMenuManager : IContextMenuManager
+    {
+        // Base paths for .desktop files
+        // User-specific actions (e.g., Nautilus, Caja, Nemo)
+        private const string UserActionsPath1 = ".local/share/file-manager/actions/";
+        // User-specific actions (e.g., KDE Dolphin)
+        private const string UserKdeServiceMenusPath = ".local/share/kservices5/ServiceMenus/";
+        // System-wide actions (requires root privileges to write here)
+        private const string SystemActionsPath = "/usr/share/file-manager/actions/";
+        // System-wide KDE actions
+        private const string SystemKdeServiceMenusPath = "/usr/share/kservices5/ServiceMenus/";
+
+        // TODO: Inject or configure a logger
+        // private readonly ILogger _logger;
+
+        // public LinuxContextMenuManager(ILogger logger)
+        // {
+        //     _logger = logger;
+        // }
+
+        /// <summary>
+        /// Adds a new entry to the context menu by creating a .desktop file.
+        /// </summary>
+        /// <param name="entry">The context menu entry to add.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task AddEntryAsync(ContextMenuEntry entry)
+        {
+            if (entry == null)
+            {
+                // _logger.LogWarning("Attempted to add a null context menu entry.");
+                throw new ArgumentNullException(nameof(entry));
+            }
+            if (string.IsNullOrWhiteSpace(entry.Id))
+            {
+                // _logger.LogWarning("Attempted to add a context menu entry with a null or empty ID.");
+                throw new ArgumentException("Entry ID cannot be null or empty.", nameof(entry.Id));
+            }
+
+            string basePath = GetBasePath(entry.Scope);
+            // For simplicity, we'll primarily target the generic file-manager/actions path.
+            // For KDE, a different path or even a different file format might be more appropriate.
+            // We'll use UserActionsPath1 for user scope. A more robust solution might detect the DE.
+            string directoryPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), basePath);
+
+            if (entry.Scope == MenuScope.System)
+            {
+                directoryPath = basePath; // System paths are absolute
+                // _logger.LogInformation($"System scope selected. Path: {directoryPath}. This typically requires root privileges.");
+            }
+
+            try
+            {
+                Directory.CreateDirectory(directoryPath); // Ensure the directory exists
+
+                string desktopFilePath = Path.Combine(directoryPath, $"{entry.Id}.desktop");
+                string desktopFileContent = GenerateDesktopFileContent(entry);
+
+                await File.WriteAllTextAsync(desktopFilePath, desktopFileContent, Encoding.UTF8);
+                // _logger.LogInformation($"Successfully added context menu entry: {entry.Id} at {desktopFilePath}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // _logger.LogError(ex, $"Permission denied when trying to add context menu entry: {entry.Id} to {directoryPath}. For system scope, ensure you have root privileges.");
+                throw new UnauthorizedAccessException($"Permission denied for path {directoryPath}. Ensure correct permissions.", ex);
+            }
+            catch (Exception ex)
+            {
+                // _logger.LogError(ex, $"Failed to add context menu entry: {entry.Id}");
+                throw new IOException($"Failed to add context menu entry '{entry.Id}'.", ex);
+            }
+        }
+
+        /// <summary>
+        /// Removes an entry from the context menu by deleting its .desktop file.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to remove (filename without .desktop extension).</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public Task RemoveEntryAsync(string entryId)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+            {
+                // _logger.LogWarning("Attempted to remove a context menu entry with a null or empty ID.");
+                throw new ArgumentException("Entry ID cannot be null or empty.", nameof(entryId));
+            }
+
+            // Try to remove from user paths first, then system paths.
+            // This is a simplification; a robust solution might store where an entry was created.
+            var potentialPaths = new List<string>
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), UserActionsPath1, $"{entryId}.desktop"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), UserKdeServiceMenusPath, $"{entryId}.desktop"),
+                Path.Combine(SystemActionsPath, $"{entryId}.desktop"),
+                Path.Combine(SystemKdeServiceMenusPath, $"{entryId}.desktop")
+            };
+
+            bool removed = false;
+            foreach (var path in potentialPaths)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                        // _logger.LogInformation($"Successfully removed context menu entry: {entryId} from {path}");
+                        removed = true;
+                        break; // Found and removed
+                    }
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    // _logger.LogWarning(ex, $"Permission denied when trying to remove context menu entry: {entryId} from {path}.");
+                    // Continue trying other paths, but rethrow if it's the only place it existed and failed.
+                    // For simplicity, we just log and continue. If it's critical, this logic needs refinement.
+                }
+                catch (Exception ex)
+                {
+                    // _logger.LogError(ex, $"Failed to remove context menu entry: {entryId} from {path}");
+                    // Potentially rethrow or handle more gracefully
+                    throw new IOException($"Error removing context menu entry '{entryId}' from '{path}'.", ex);
+                }
+            }
+
+            if (!removed)
+            {
+                // _logger.LogInformation($"Context menu entry not found for removal: {entryId}");
+                // Consider if this should be an error or just a silent failure if not found.
+                // For now, if it's not found in any standard location, we assume it's already gone or never existed.
+            }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Checks if a context menu entry exists by looking for its .desktop file.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to check (filename without .desktop extension).</param>
+        /// <returns>True if the entry exists; otherwise, false.</returns>
+        public Task<bool> CheckEntryExistsAsync(string entryId)
+        {
+            if (string.IsNullOrWhiteSpace(entryId))
+            {
+                // _logger.LogWarning("Attempted to check a context menu entry with a null or empty ID.");
+                return Task.FromResult(false); // Or throw ArgumentException
+            }
+
+            var potentialPaths = new List<string>
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), UserActionsPath1, $"{entryId}.desktop"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), UserKdeServiceMenusPath, $"{entryId}.desktop"),
+                Path.Combine(SystemActionsPath, $"{entryId}.desktop"),
+                Path.Combine(SystemKdeServiceMenusPath, $"{entryId}.desktop")
+            };
+
+            foreach (var path in potentialPaths)
+            {
+                if (File.Exists(path))
+                {
+                    // _logger.LogInformation($"Context menu entry found: {entryId} at {path}");
+                    return Task.FromResult(true);
+                }
+            }
+
+            // _logger.LogInformation($"Context menu entry not found: {entryId}");
+            return Task.FromResult(false);
+        }
+
+        /// <summary>
+        /// Retrieves all context menu entries managed by this application.
+        /// NOTE: This implementation is a placeholder as per requirements.
+        /// A full implementation would require scanning directories and parsing .desktop files,
+        /// potentially with a specific marker to identify application-managed entries.
+        /// </summary>
+        /// <returns>An empty list of context menu entries.</returns>
+        public Task<IEnumerable<ContextMenuEntry>> GetEntriesAsync()
+        {
+            // _logger.LogInformation("GetEntriesAsync called, returning empty list as per current design.");
+            // A full implementation would scan relevant directories (UserActionsPath1, UserKdeServiceMenusPath, etc.)
+            // and parse .desktop files, possibly looking for a custom field to identify entries managed by this app.
+            return Task.FromResult(Enumerable.Empty<ContextMenuEntry>());
+        }
+
+        /// <summary>
+        /// Gets the base directory path for context menu entries based on scope.
+        /// </summary>
+        private string GetBasePath(MenuScope scope)
+        {
+            // Prioritize generic file-manager/actions path.
+            // A more sophisticated approach might detect the desktop environment.
+            switch (scope)
+            {
+                case MenuScope.User:
+                    // Could also check for KDE and return UserKdeServiceMenusPath
+                    return UserActionsPath1;
+                case MenuScope.System:
+                    // Could also check for KDE and return SystemKdeServiceMenusPath
+                    return SystemActionsPath;
+                default:
+                    // _logger.LogWarning($"Unknown MenuScope: {scope}. Defaulting to user path.");
+                    return UserActionsPath1; // Default to user-specific path
+            }
+        }
+
+        /// <summary>
+        /// Generates the content for a .desktop file based on the ContextMenuEntry.
+        /// </summary>
+        private string GenerateDesktopFileContent(ContextMenuEntry entry)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("[Desktop Entry]");
+            sb.AppendLine("Type=Action");
+            sb.AppendLine($"Name={entry.Text}");
+
+            if (!string.IsNullOrWhiteSpace(entry.IconPath))
+            {
+                sb.AppendLine($"Icon={entry.IconPath}");
+            }
+
+            string profileString;
+            string execCommand = $"{entry.Command}";
+            if (!string.IsNullOrWhiteSpace(entry.Arguments))
+            {
+                execCommand += $" {entry.Arguments}";
+            }
+
+            // Determine profile string and exec parameter based on TargetType
+            // %F for list of files/dirs, %f for single file, %U for list of URLs, %u for single URL
+            // %d for single directory (if action is on background), %D for list of directories
+            // For simplicity, using %F as a general case for files/folders.
+            // Background might need %d or the current directory.
+            // The prompt suggests "%F {entry.Arguments}" for Exec.
+            // Let's refine the profile string and exec based on TargetType.
+
+            string mimeTypeCondition = ""; // For MimeType based activation
+
+            switch (entry.TargetType)
+            {
+                case TargetType.File:
+                    profileString = "nodirs"; // Appears for files, not for directories
+                    execCommand = $"{execCommand} %F"; // %F for multiple files
+                    // mimeTypeCondition = "MimeType=text/plain;application/pdf;"; // Example
+                    break;
+                case TargetType.Folder:
+                    profileString = "dirs";   // Appears for directories
+                    execCommand = $"{execCommand} %F"; // %F for multiple directories (paths)
+                    break;
+                case TargetType.Drive: // Treat drives similar to folders for .desktop actions
+                    profileString = "dirs";
+                    execCommand = $"{execCommand} %F";
+                    break;
+                case TargetType.Background:
+                    // For background, the action is on the directory itself.
+                    // 'dirs' profile makes it appear on directories.
+                    // The command might need the current directory path, often %d.
+                    profileString = "dirs"; // To make it appear when a directory is selected or for directory background.
+                                            // Some file managers might use a different mechanism or profile for background.
+                                            // For Nautilus, actions in `~/.local/share/nautilus/scripts` are simpler for background.
+                                            // Here, we assume the action is associated with the directory itself.
+                    execCommand = $"{execCommand} %d"; // %d for the current directory when action is on background
+                    break;
+                default:
+                    profileString = "allfiles"; // Fallback: appears for all files and directories
+                    execCommand = $"{execCommand} %F";
+                    break;
+            }
+
+            sb.AppendLine($"Profiles={profileString};");
+            sb.AppendLine();
+            sb.AppendLine($"[X-Action-Profile {profileString}]");
+            sb.AppendLine($"Name={entry.Text}"); // Name again under profile
+            sb.AppendLine($"Exec={execCommand}");
+            // If MimeTypes are preferred over profiles for some file managers or more specific targeting:
+            // if (!string.IsNullOrWhiteSpace(mimeTypeCondition))
+            // {
+            //     sb.AppendLine(mimeTypeCondition);
+            // }
+            // else
+            // {
+            //    sb.AppendLine($"Profiles={profileString};");
+            // }
+
+
+            return sb.ToString();
+        }
+    }
+}

--- a/CommonUtilities/Services/OSIntegration/Windows/WindowsContextMenuManager.cs
+++ b/CommonUtilities/Services/OSIntegration/Windows/WindowsContextMenuManager.cs
@@ -1,0 +1,372 @@
+using CommonUtilities.Interfaces;
+using CommonUtilities.Models;
+using CommonUtilities.Models.Enums;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security;
+using System.Threading.Tasks;
+
+namespace CommonUtilities.Services.OSIntegration.Windows
+{
+    /// <summary>
+    /// Manages context menu entries for Windows.
+    /// </summary>
+    public class WindowsContextMenuManager : IContextMenuManager
+    {
+        private const string AppRegistrySubKey = @"Software\EasyKit\ContextMenuEntries"; // A place to store our app-specific entry details
+
+        /// <summary>
+        /// Adds a new entry to the Windows context menu.
+        /// </summary>
+        /// <param name="entry">The context menu entry to add.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public Task AddEntryAsync(ContextMenuEntry entry)
+        {
+            // Placeholder for logging: LoggerUtilities.Log($"Adding context menu entry: {entry.Id}");
+            try
+            {
+                RegistryKey? baseKey = GetBaseKey(entry.Scope);
+                if (baseKey == null)
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"Unsupported scope: {entry.Scope} for entry: {entry.Id}", LogLevel.Error);
+                    return Task.CompletedTask; // Or throw an exception
+                }
+
+                string targetPath = GetRegistryPathForTarget(entry.TargetType);
+                if (string.IsNullOrEmpty(targetPath))
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"Unsupported target type: {entry.TargetType} for entry: {entry.Id}", LogLevel.Error);
+                    return Task.CompletedTask; // Or throw an exception
+                }
+
+                // Use entry.Id for the key name to ensure uniqueness and easy removal
+                string entryKeyName = entry.Id;
+                if (string.IsNullOrWhiteSpace(entryKeyName))
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"Entry Id cannot be empty for entry: {entry.Text}", LogLevel.Error);
+                    throw new ArgumentException("Entry Id cannot be empty.", nameof(entry.Id));
+                }
+
+                using (RegistryKey? shellKey = baseKey.CreateSubKey(Path.Combine(targetPath, entryKeyName), true))
+                {
+                    if (shellKey == null)
+                    {
+                        // Placeholder for logging: LoggerUtilities.Log($"Failed to create shell key for entry: {entry.Id}", LogLevel.Error);
+                        return Task.CompletedTask;
+                    }
+                    shellKey.SetValue("", entry.Text); // Set the display text
+                    if (!string.IsNullOrWhiteSpace(entry.IconPath))
+                    {
+                        shellKey.SetValue("Icon", entry.IconPath);
+                    }
+
+                    using (RegistryKey? commandKey = shellKey.CreateSubKey("command", true))
+                    {
+                        if (commandKey == null)
+                        {
+                            // Placeholder for logging: LoggerUtilities.Log($"Failed to create command key for entry: {entry.Id}", LogLevel.Error);
+                            return Task.CompletedTask;
+                        }
+                        string commandValue = $"\"{entry.Command}\" \"%1\"";
+                        if (!string.IsNullOrWhiteSpace(entry.Arguments))
+                        {
+                            commandValue += $" {entry.Arguments}";
+                        }
+                        commandKey.SetValue("", commandValue);
+                    }
+                }
+
+                // Store metadata for GetEntriesAsync and easier management
+                StoreEntryMetadata(entry);
+
+                // Placeholder for logging: LoggerUtilities.Log($"Successfully added context menu entry: {entry.Id}");
+            }
+            catch (SecurityException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"SecurityException while adding entry {entry.Id}: {ex.Message}", LogLevel.Error);
+                // Potentially re-throw or handle as appropriate for the application
+                throw;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"UnauthorizedAccessException while adding entry {entry.Id}: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Exception while adding entry {entry.Id}: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Removes an entry from the Windows context menu.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to remove.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public Task RemoveEntryAsync(string entryId)
+        {
+            // Placeholder for logging: LoggerUtilities.Log($"Removing context menu entry: {entryId}");
+            try
+            {
+                // Retrieve metadata to know where the entry was created
+                ContextMenuEntry? entryMeta = GetStoredEntryMetadata(entryId);
+                if (entryMeta == null)
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"No metadata found for entryId: {entryId}. Cannot determine scope or target type for removal.", LogLevel.Warning);
+                    // Attempt removal from common paths if metadata is missing (less reliable)
+                    // For now, we'll assume metadata exists or removal fails.
+                    // A more robust solution would iterate through all possible TargetType/Scope combinations.
+                    return Task.CompletedTask;
+                }
+
+                RegistryKey? baseKey = GetBaseKey(entryMeta.Scope);
+                if (baseKey == null)
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"Unsupported scope: {entryMeta.Scope} for entry: {entryId}", LogLevel.Error);
+                    return Task.CompletedTask;
+                }
+
+                string targetPath = GetRegistryPathForTarget(entryMeta.TargetType);
+                if (string.IsNullOrEmpty(targetPath))
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"Unsupported target type: {entryMeta.TargetType} for entry: {entryId}", LogLevel.Error);
+                    return Task.CompletedTask;
+                }
+
+                baseKey.DeleteSubKeyTree(Path.Combine(targetPath, entryId), false); // false: do not throw if not found
+
+                RemoveStoredEntryMetadata(entryId);
+                // Placeholder for logging: LoggerUtilities.Log($"Successfully removed context menu entry: {entryId}");
+            }
+            catch (SecurityException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"SecurityException while removing entry {entryId}: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"UnauthorizedAccessException while removing entry {entryId}: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+            catch (ArgumentException ex) // Can be thrown by DeleteSubKeyTree if key doesn't exist and throwOnMissing is true (though we use false)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"ArgumentException (key likely not found) while removing entry {entryId}: {ex.Message}", LogLevel.Warning);
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Exception while removing entry {entryId}: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Checks if a context menu entry exists in the Windows Registry.
+        /// </summary>
+        /// <param name="entryId">The unique identifier of the context menu entry to check.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains true if the entry exists; otherwise, false.</returns>
+        public Task<bool> CheckEntryExistsAsync(string entryId)
+        {
+            // Placeholder for logging: LoggerUtilities.Log($"Checking if context menu entry exists: {entryId}");
+            try
+            {
+                ContextMenuEntry? entryMeta = GetStoredEntryMetadata(entryId);
+                if (entryMeta == null)
+                {
+                    // Placeholder for logging: LoggerUtilities.Log($"No metadata found for entryId: {entryId}. Cannot determine scope or target type for check.", LogLevel.Warning);
+                    return Task.FromResult(false); // If we don't know where it should be, assume it doesn't exist.
+                }
+
+                RegistryKey? baseKey = GetBaseKey(entryMeta.Scope);
+                if (baseKey == null) return Task.FromResult(false);
+
+                string targetPath = GetRegistryPathForTarget(entryMeta.TargetType);
+                if (string.IsNullOrEmpty(targetPath)) return Task.FromResult(false);
+
+                using (RegistryKey? entryKey = baseKey.OpenSubKey(Path.Combine(targetPath, entryId)))
+                {
+                    return Task.FromResult(entryKey != null);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Exception while checking entry {entryId}: {ex.Message}", LogLevel.Error);
+                return Task.FromResult(false); // On error, assume it doesn't exist or cannot be verified
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all custom context menu entries managed by this application from the Windows Registry.
+        /// This implementation relies on metadata stored by the application.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a collection of all context menu entries.</returns>
+        public Task<IEnumerable<ContextMenuEntry>> GetEntriesAsync()
+        {
+            // Placeholder for logging: LoggerUtilities.Log("Getting all managed context menu entries.");
+            var entries = new List<ContextMenuEntry>();
+            try
+            {
+                // Iterate over both HKEY_CURRENT_USER and HKEY_LOCAL_MACHINE for our app's metadata
+                ProcessScopeForGetEntries(Registry.CurrentUser, entries);
+                ProcessScopeForGetEntries(Registry.LocalMachine, entries);
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Exception while getting entries: {ex.Message}", LogLevel.Error);
+                // Return what we have, or an empty list if critical error
+            }
+            return Task.FromResult<IEnumerable<ContextMenuEntry>>(entries);
+        }
+
+        private void ProcessScopeForGetEntries(RegistryKey rootKey, List<ContextMenuEntry> entries)
+        {
+            try
+            {
+                using (RegistryKey? appMetaKey = rootKey.OpenSubKey(AppRegistrySubKey, false))
+                {
+                    if (appMetaKey != null)
+                    {
+                        foreach (string entryId in appMetaKey.GetSubKeyNames())
+                        {
+                            ContextMenuEntry? entry = GetStoredEntryMetadata(entryId, rootKey);
+                            if (entry != null)
+                            {
+                                entries.Add(entry);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (SecurityException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"SecurityException while accessing metadata in {rootKey.Name}: {ex.Message}", LogLevel.Warning);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"UnauthorizedAccessException while accessing metadata in {rootKey.Name}: {ex.Message}", LogLevel.Warning);
+            }
+        }
+
+
+        private RegistryKey? GetBaseKey(MenuScope scope)
+        {
+            return scope switch
+            {
+                MenuScope.User => Registry.CurrentUser,
+                MenuScope.System => Registry.LocalMachine,
+                _ => null,
+            };
+        }
+
+        private string GetRegistryPathForTarget(TargetType targetType)
+        {
+            return targetType switch
+            {
+                TargetType.File => @"Software\Classes\*\shell",
+                TargetType.Folder => @"Software\Classes\Directory\shell", // Changed from Directory
+                TargetType.Background => @"Software\Classes\Directory\Background\shell", // Changed from DirectoryBackground and covers DesktopBackground conceptually
+                TargetType.Drive => @"Software\Classes\Drive\shell",
+                // Removed AllFilesAndFolders as it's not in the TargetType enum
+                // Removed DesktopBackground as it's covered by Background
+                _ => string.Empty,
+            };
+        }
+
+        private void StoreEntryMetadata(ContextMenuEntry entry)
+        {
+            RegistryKey? baseKey = GetBaseKey(entry.Scope);
+            if (baseKey == null) return;
+
+            try
+            {
+                using (RegistryKey? entryMetaKey = baseKey.CreateSubKey(Path.Combine(AppRegistrySubKey, entry.Id), true))
+                {
+                    if (entryMetaKey == null) return;
+                    entryMetaKey.SetValue("Text", entry.Text);
+                    entryMetaKey.SetValue("Command", entry.Command);
+                    entryMetaKey.SetValue("Arguments", entry.Arguments ?? string.Empty);
+                    entryMetaKey.SetValue("IconPath", entry.IconPath ?? string.Empty);
+                    entryMetaKey.SetValue("TargetType", entry.TargetType.ToString());
+                    entryMetaKey.SetValue("Scope", entry.Scope.ToString()); // Store scope as well for completeness
+                }
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Failed to store metadata for {entry.Id}: {ex.Message}", LogLevel.Error);
+            }
+        }
+
+        private ContextMenuEntry? GetStoredEntryMetadata(string entryId, RegistryKey? specificBaseKey = null)
+        {
+            RegistryKey? baseKeyToSearchFirst = specificBaseKey;
+            RegistryKey? baseKeyToSearchSecond = null;
+
+            if (baseKeyToSearchFirst == null) // If no specific base key, try both
+            {
+                baseKeyToSearchFirst = Registry.CurrentUser;
+                baseKeyToSearchSecond = Registry.LocalMachine;
+            }
+
+            ContextMenuEntry? entry = TryGetMetadataFromKey(baseKeyToSearchFirst, entryId);
+            if (entry == null && baseKeyToSearchSecond != null)
+            {
+                entry = TryGetMetadataFromKey(baseKeyToSearchSecond, entryId);
+            }
+            return entry;
+        }
+
+        private ContextMenuEntry? TryGetMetadataFromKey(RegistryKey baseKey, string entryId)
+        {
+            try
+            {
+                using (RegistryKey? entryMetaKey = baseKey.OpenSubKey(Path.Combine(AppRegistrySubKey, entryId), false))
+                {
+                    if (entryMetaKey == null) return null;
+
+                    return new ContextMenuEntry
+                    {
+                        Id = entryId,
+                        Text = entryMetaKey.GetValue("Text") as string ?? string.Empty,
+                        Command = entryMetaKey.GetValue("Command") as string ?? string.Empty,
+                        Arguments = entryMetaKey.GetValue("Arguments") as string ?? string.Empty,
+                        IconPath = entryMetaKey.GetValue("IconPath") as string ?? string.Empty,
+                        TargetType = Enum.TryParse<TargetType>(entryMetaKey.GetValue("TargetType") as string, out var tt) ? tt : default,
+                        Scope = Enum.TryParse<MenuScope>(entryMetaKey.GetValue("Scope") as string, out var ms) ? ms : default
+                    };
+                }
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Failed to get metadata for {entryId} from {baseKey.Name}: {ex.Message}", LogLevel.Warning);
+                return null;
+            }
+        }
+
+
+        private void RemoveStoredEntryMetadata(string entryId)
+        {
+            // Try removing from both scopes, as we might not know which one it was if GetStoredEntryMetadata failed before this call
+            RemoveMetadataFromScope(Registry.CurrentUser, entryId);
+            RemoveMetadataFromScope(Registry.LocalMachine, entryId);
+        }
+
+        private void RemoveMetadataFromScope(RegistryKey baseKey, string entryId)
+        {
+            try
+            {
+                using (RegistryKey? appMetaKey = baseKey.OpenSubKey(AppRegistrySubKey, true)) // Open with write access
+                {
+                    appMetaKey?.DeleteSubKeyTree(entryId, false); // false: do not throw if not found
+                }
+            }
+            catch (Exception ex)
+            {
+                // Placeholder for logging: LoggerUtilities.Log($"Failed to remove metadata for {entryId} from {baseKey.Name}: {ex.Message}", LogLevel.Warning);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a framework for managing context menu entries, including a new interface, supporting models, and an initial implementation for Linux-based systems. The changes establish a foundation for creating, removing, checking, and retrieving context menu entries programmatically, with a focus on extensibility and platform-specific integration.

### Interface and Models:

* **`IContextMenuManager` interface**: Added to define the contract for managing context menu entries, including methods for adding, removing, checking, and retrieving entries. (`CommonUtilities/Interfaces/IContextMenuManager.cs`)
* **`ContextMenuEntry` model**: Introduced to represent a context menu entry, including properties such as `Id`, `Text`, `Command`, `Arguments`, `IconPath`, `TargetType`, and `Scope`. (`CommonUtilities/Models/ContextMenuEntry.cs`)
* **Enums for `MenuScope` and `TargetType`**: Added `MenuScope` to define user/system-level scope and `TargetType` to specify the target type (e.g., File, Folder, Drive, Background). (`CommonUtilities/Models/Enums/MenuScope.cs`, `CommonUtilities/Models/Enums/TargetType.cs`) [[1]](diffhunk://#diff-411d802cf5b179427285730cebfe040598381c74d56c788e66f665306205bbc4R1-R17) [[2]](diffhunk://#diff-23c5d6fb035acb0a0fdd9813cf7974ebfd4d7af171954047296dfe33fbe1df4bR1-R25)

### Linux-specific Implementation:

* **`LinuxContextMenuManager` class**: Implements the `IContextMenuManager` interface for Linux environments. It uses `.desktop` files to manage context menu entries and includes methods for adding, removing, and checking entries, as well as retrieving all entries. (`CommonUtilities/Services/OSIntegration/Linux/LinuxContextMenuManager.cs`)