### PR TITLE
Release 1.6.3

### DIFF
--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -20,6 +20,27 @@ jobs:
           - os: windows-latest
             arch: x86
             runtime: win-x86
+          - os: windows-latest
+            arch: arm
+            runtime: win-arm
+          - os: windows-latest
+            arch: arm64
+            runtime: win-arm64
+          - os: macos-latest
+            arch: x64
+            runtime: osx-x64
+          - os: macos-latest
+            arch: arm64
+            runtime: osx-arm64
+          - os: ubuntu-latest
+            arch: x64
+            runtime: linux-x64
+          - os: ubuntu-latest
+            arch: arm
+            runtime: linux-arm
+          - os: ubuntu-latest
+            arch: arm64
+            runtime: linux-arm64
 
     steps:
       - name: Checkout repository
@@ -57,17 +78,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download Windows x64 artifact
+      - name: Download all platform artifacts
         uses: actions/download-artifact@v4
         with:
-          name: CommonUtilities-${{ inputs.release_version }}-x64.zip
           path: ./release-assets
-      - name: Download Windows x86 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: CommonUtilities-${{ inputs.release_version }}-x86.zip
-          path: ./release-assets
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
@@ -77,5 +91,12 @@ jobs:
           files: |
             ./release-assets/CommonUtilities-${{ inputs.release_version }}-x64.zip
             ./release-assets/CommonUtilities-${{ inputs.release_version }}-x86.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-arm.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-arm64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-osx-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-osx-arm64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-arm.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-arm64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -97,6 +97,6 @@ jobs:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
           prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
-          files: ./release-assets/*.zip
+          files: ./release-assets/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -60,16 +60,16 @@ jobs:
       - name: Publish library
         run: dotnet publish CommonUtilities/CommonUtilities.csproj --configuration Release --runtime ${{ matrix.runtime }} --self-contained false /p:UseAppHost=false -o ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities
 
-      - name: Zip ${{ matrix.arch }} output
+      - name: Zip ${{ matrix.os }}-${{ matrix.arch }} output
         run: |
-          Compress-Archive -Path ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities/* -DestinationPath ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
+          Compress-Archive -Path ./publish/${{ matrix.os }}-${{ matrix.arch }}/CommonUtilities/* -DestinationPath ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.os }}-${{ matrix.arch }}.zip
         shell: pwsh
 
-      - name: Upload ${{ matrix.arch }} artifact
+      - name: Upload ${{ matrix.os }}-${{ matrix.arch }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
-          path: ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.arch }}.zip
+          name: CommonUtilities-${{ inputs.release_version }}-${{ matrix.os }}-${{ matrix.arch }}.zip
+          path: ./CommonUtilities-${{ inputs.release_version }}-${{ matrix.os }}-${{ matrix.arch }}.zip
           overwrite: true
 
   release:
@@ -89,14 +89,14 @@ jobs:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
           files: |
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-x86.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-arm.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-arm64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-osx-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-osx-arm64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-arm.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-linux-arm64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x86.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-arm.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-arm64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-macos-latest-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-macos-latest-arm64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-x64.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-arm.zip
+            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-arm64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -7,6 +7,14 @@ on:
         description: "Desired Release Version (e.g., v1.0.0)"
         required: true
         type: string
+      release_type:
+        description: "Release type (release or prerelease)"
+        required: true
+        default: "release"
+        type: choice
+        options:
+          - release
+          - prerelease
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -88,6 +96,7 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
+          prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
           files: |
             ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x64.zip
             ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x86.zip

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -97,15 +97,6 @@ jobs:
           tag_name: ${{ github.event.inputs.release_version }}
           name: ${{ github.event.inputs.release_version }}
           prerelease: ${{ github.event.inputs.release_type == 'prerelease' }}
-          files: |
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-x86.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-arm.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-windows-latest-arm64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-macos-latest-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-macos-latest-arm64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-x64.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-arm.zip
-            ./release-assets/CommonUtilities-${{ inputs.release_version }}-ubuntu-latest-arm64.zip
+          files: ./release-assets/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -47,13 +47,13 @@
 	<ItemGroup>
 		<PackageReference Include="Cronos" Version="0.11.0" />
 		<PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
-		<PackageReference Include="MailKit" Version="4.12.1" />
+		<PackageReference Include="MailKit" Version="4.13.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.3.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
 		<PackageReference Include="QRCoder" Version="1.6.0" />
 		<PackageReference Include="Razor.Templating.Core" Version="2.1.0" />
 		<PackageReference Include="RestSharp" Version="112.1.0" />
@@ -61,8 +61,8 @@
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
-		<PackageReference Include="Stripe.net" Version="48.2.0" />
-		<PackageReference Include="System.Runtime.Caching" Version="9.0.6" />
+		<PackageReference Include="Stripe.net" Version="48.3.0" />
+		<PackageReference Include="System.Runtime.Caching" Version="9.0.7" />
 	</ItemGroup>
 
 </Project>

--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -13,8 +13,8 @@
 		<Description>A modular, production-ready C#/.NET utility library and toolkit for rapid development.</Description>
 		<RepositoryUrl>https://github.com/LoveDoLove/CS_CommonUtilities</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<AssemblyVersion>1.6.2</AssemblyVersion>
-		<FileVersion>1.6.2</FileVersion>
+		<AssemblyVersion>1.6.3</AssemblyVersion>
+		<FileVersion>1.6.3</FileVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 	</PropertyGroup>


### PR DESCRIPTION
This pull request introduces significant updates to the cross-platform build workflow and the `CommonUtilities` project. It enhances the build process by adding support for more platforms and architectures, improves artifact handling, and updates dependencies to their latest versions. Below is a breakdown of the most important changes:

### Workflow Enhancements
* Added a new `release_type` input to the workflow to differentiate between `release` and `prerelease` builds, with `release` as the default option. (`.github/workflows/cross-platform-build.yml`, [.github/workflows/cross-platform-build.ymlR10-R17](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bR10-R17))
* Expanded the build matrix to include additional platforms and architectures, such as `arm`, `arm64`, and `x64` for Windows, macOS, and Ubuntu. (`.github/workflows/cross-platform-build.yml`, [.github/workflows/cross-platform-build.ymlR31-R51](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bR31-R51))
* Updated artifact naming conventions to include both OS and architecture in the filenames for better clarity. (`.github/workflows/cross-platform-build.yml`, [.github/workflows/cross-platform-build.ymlL42-R80](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL42-R80))
* Simplified artifact downloading in the release job to handle all platform artifacts dynamically, and added support for marking releases as `prerelease` based on the `release_type` input. (`.github/workflows/cross-platform-build.yml`, [.github/workflows/cross-platform-build.ymlL60-R100](diffhunk://#diff-08a9c6ab8eb1c1c3cd7ddba60b029b069a65354d1781301d66170eeff6e78e0bL60-R100))

### Project Updates
* Bumped the `AssemblyVersion` and `FileVersion` from `1.6.2` to `1.6.3` to reflect the new release. (`CommonUtilities/CommonUtilities.csproj`, [CommonUtilities/CommonUtilities.csprojL16-R17](diffhunk://#diff-f4fd00d93f98c04d1f05d97d9ac56ea8ab5e06401ce30c115a3a4b6eaa0356baL16-R17))
* Updated several NuGet package dependencies to their latest versions, including `MailKit` (4.12.1 → 4.13.0), `Microsoft.EntityFrameworkCore` (9.0.6 → 9.0.7), and others. (`CommonUtilities/CommonUtilities.csproj`, [CommonUtilities/CommonUtilities.csprojL50-R65](diffhunk://#diff-f4fd00d93f98c04d1f05d97d9ac56ea8ab5e06401ce30c115a3a4b6eaa0356baL50-R65))