### PR TITLE
Release 2.0.1

### DIFF
--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -22,7 +22,7 @@
 		<Company>LoveDoLove</Company>
 		<Version>2.0.1</Version>
 		<Title>CommonUtilities</Title>
-		<PackageId>CommonUtilities</PackageId>
+		<PackageId>LoveDoLove.CommonUtilities</PackageId>
 		<Product>CommonUtilities</Product>
 	</PropertyGroup>
 

--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -10,7 +10,7 @@
 		<PackageProjectUrl>https://github.com/LoveDoLove/CS_CommonUtilities</PackageProjectUrl>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Description>A modular, production-ready C#/.NET utility library and toolkit for rapid development.</Description>
+		<Description>CommonUtilities is a modular, production-ready C#/.NET utility library and toolkit designed to accelerate development for .NET 8+ projects. It contains a broad set of helpers, models, and utilities for common application needs (security, data, HTTP, scheduling, media, cloud integrations, and more). The codebase is organized for easy consumption as a project reference or compiled library.</Description>
 		<RepositoryUrl>https://github.com/LoveDoLove/CS_CommonUtilities</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<AssemblyVersion>2.0.1</AssemblyVersion>
@@ -22,6 +22,8 @@
 		<Company>LoveDoLove</Company>
 		<Version>2.0.1</Version>
 		<Title>CommonUtilities</Title>
+		<PackageId>CommonUtilities</PackageId>
+		<Product>CommonUtilities</Product>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/CommonUtilities/CommonUtilities.csproj
+++ b/CommonUtilities/CommonUtilities.csproj
@@ -13,14 +13,14 @@
 		<Description>A modular, production-ready C#/.NET utility library and toolkit for rapid development.</Description>
 		<RepositoryUrl>https://github.com/LoveDoLove/CS_CommonUtilities</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<AssemblyVersion>2.0.0</AssemblyVersion>
-		<FileVersion>2.0.0</FileVersion>
+		<AssemblyVersion>2.0.1</AssemblyVersion>
+		<FileVersion>2.0.1</FileVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Authors>LoveDoLove</Authors>
 		<Company>LoveDoLove</Company>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<Title>CommonUtilities</Title>
 	</PropertyGroup>
 
@@ -57,21 +57,16 @@
 		<PackageReference Include="Google_GenerativeAI" Version="3.4.1" />
 		<PackageReference Include="HtmlSanitizer" Version="9.0.889" />
 		<PackageReference Include="MailKit" Version="4.14.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.3.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.11" />
 		<PackageReference Include="QRCoder" Version="1.7.0" />
 		<PackageReference Include="Razor.Templating.Core" Version="2.1.0" />
 		<PackageReference Include="RestSharp" Version="113.0.0" />
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
 		<PackageReference Include="Stripe.net" Version="50.0.0" />
-		<PackageReference Include="System.Runtime.Caching" Version="10.0.0" />
+		<PackageReference Include="System.Runtime.Caching" Version="9.0.11" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the `CommonUtilities` library to version 2.0.1, focusing on improving package metadata, updating dependencies, and refactoring the `AdvancedHttpUtilities` class for better clarity and compatibility. The most significant changes are grouped below:

**Project metadata and packaging improvements:**

* Enhanced the package description in `CommonUtilities.csproj` to provide a clearer overview of supported features and .NET compatibility, and added `PackageId` and `Product` fields for better NuGet identification. The version was bumped to 2.0.1, and package generation is now enabled by default.

**Dependency updates and cleanup:**

* Removed several unused or unnecessary package references (e.g., `Microsoft.AspNetCore.*`, `Microsoft.Data.SqlClient`, `Microsoft.Extensions.Configuration.Json`, `Microsoft.VisualStudio.Azure.Containers.Tools.Targets`, `Microsoft.EntityFrameworkCore`) and updated others for compatibility (e.g., switched to `Microsoft.EntityFrameworkCore.SqlServer` v9.0.11, downgraded `Serilog.Extensions.Hosting` to v9.0.0, and `System.Runtime.Caching` to v9.0.11).

**Refactoring and code improvements in `AdvancedHttpUtilities`:**

* Updated the default User-Agent to a modern browser string for better compatibility with web servers.
* Renamed private fields (`_clientCache` and `_lock`) to `ClientCache` and `Lock` for consistency and clarity, and updated all usages accordingly. [[1]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L36-R39) [[2]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L62-R64) [[3]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L79-R79) [[4]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L367-R376) [[5]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L387-R387)
* Added `where T : notnull` constraints to all generic async HTTP methods to enforce type safety. [[1]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L105-R105) [[2]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L211-R211) [[3]](diffhunk://#diff-b0916c99287eabc28b9e99fd9b219bc4c22cacd4926b758fffa66297c04bc272L255-R255)